### PR TITLE
Footer improvements

### DIFF
--- a/wp-content/themes/classicpress-directory/footer.php
+++ b/wp-content/themes/classicpress-directory/footer.php
@@ -29,10 +29,11 @@
 			<div class="footerright">
 				<div class="menu-footermenu-container">
 					<ul id="footmenu" class="nav">
-						<li class="menu-item menu-item-type-post_type menu-item-object-page"><a href="/developers/">Developer Directory</a></li>
 						<li class="menu-item menu-item-type-custom menu-item-object-custom"><a target="_blank" rel="noreferrer noopener" href="https://docs.classicpress.net/plugin-guidelines/">Plugin Guidelines</a></li>
+						<li class="menu-item menu-item-type-custom menu-item-object-custom"><a target="_blank" rel="noreferrer noopener" href="https://docs.classicpress.net/theme-guidelines/">Theme Guidelines</a></li>
 						<li class="menu-item menu-item-type-custom menu-item-object-custom"><a target="_blank" rel="noreferrer noopener" href="https://docs.classicpress.net/plugin-guidelines/directory-requirements/">Directory Requirements</a></li>
 						<li class="menu-item menu-item-type-custom menu-item-object-custom"><a target="_blank" rel="noreferrer noopener" href="https://forums.classicpress.net/c/support/directory-support/75">Directory Support</a></li>
+						<li class="menu-item menu-item-type-post_type menu-item-object-page"><a href="/developers/">Developer Directory</a></li>
 					</ul>
 				</div>
 			</div>
@@ -43,6 +44,7 @@
 						<li class="menu-item menu-item-type-custom menu-item-object-custom"><a target="_blank" rel="noreferrer noopener" href="https://forums.classicpress.net/c/support">Forum Support</a></li>
 						<li class="menu-item menu-item-type-custom menu-item-object-custom"><a target="_blank" rel="noreferrer noopener" href="https://www.classicpress.net/join-slack/">Join on Slack</a></li>
 						<li class="menu-item menu-item-type-custom menu-item-object-custom"><a target="_blank" rel="noreferrer noopener" href="https://github.com/ClassicPress/ClassicPress/issues/new/choose">Feature Requests</a></li>
+						<li class="menu-item menu-item-type-custom menu-item-object-custom"><a target="_blank" rel="noreferrer noopener" href="https://opencollective.com/classicpress">Make a Donation</a></li>
 					</ul>
 				</div>
 			</div>

--- a/wp-content/themes/classicpress-directory/footer.php
+++ b/wp-content/themes/classicpress-directory/footer.php
@@ -29,10 +29,20 @@
 			<div class="footerright">
 				<div class="menu-footermenu-container">
 					<ul id="footmenu" class="nav">
+						<li class="menu-item menu-item-type-post_type menu-item-object-page"><a href="/developers/">Developer Directory</a></li>
+						<li class="menu-item menu-item-type-custom menu-item-object-custom"><a target="_blank" rel="noreferrer noopener" href="https://docs.classicpress.net/plugin-guidelines/">Plugin Guidelines</a></li>
+						<li class="menu-item menu-item-type-custom menu-item-object-custom"><a target="_blank" rel="noreferrer noopener" href="https://docs.classicpress.net/plugin-guidelines/directory-requirements/">Directory Requirements</a></li>
+						<li class="menu-item menu-item-type-custom menu-item-object-custom"><a target="_blank" rel="noreferrer noopener" href="https://forums.classicpress.net/c/support/directory-support/75">Directory Support</a></li>
+					</ul>
+				</div>
+			</div>
+			<div class="footerright">
+				<div class="menu-footermenu-container">
+					<ul id="footmenu" class="nav">
 						<li class="menu-item menu-item-type-post_type menu-item-object-page"><a href="https://www.classicpress.net/contact/">Contact Us</a></li>
-						<li class="menu-item menu-item-type-custom menu-item-object-custom"><a target="_blank" rel="noreferrer noopener" href="https://forums.classicpress.net/c/support">Get Support</a></li>
-						<li class="menu-item menu-item-type-custom menu-item-object-custom"><a target="_blank" rel="noreferrer noopener" href="https://www.classicpress.net/join-slack/">Chat with us on Slack</a></li>
-						<li class="menu-item menu-item-type-custom menu-item-object-custom"><a target="_blank" rel="noreferrer noopener" href="https://forums.classicpress.net/c/governance/petitions/77">Start or Vote on a Petition</a></li>
+						<li class="menu-item menu-item-type-custom menu-item-object-custom"><a target="_blank" rel="noreferrer noopener" href="https://forums.classicpress.net/c/support">Forum Support</a></li>
+						<li class="menu-item menu-item-type-custom menu-item-object-custom"><a target="_blank" rel="noreferrer noopener" href="https://www.classicpress.net/join-slack/">Join on Slack</a></li>
+						<li class="menu-item menu-item-type-custom menu-item-object-custom"><a target="_blank" rel="noreferrer noopener" href="https://github.com/ClassicPress/ClassicPress/issues/new/choose">Feature Requests</a></li>
 					</ul>
 				</div>
 			</div>

--- a/wp-content/themes/classicpress-directory/style.css
+++ b/wp-content/themes/classicpress-directory/style.css
@@ -824,6 +824,12 @@ nav ul li:focus-within ul {
 	justify-content: right;
 	flex-wrap: wrap;
 }
+.show-loggedin{
+	display: none;
+}
+.logged-in .show-loggedin{
+	display: unset;
+}
 /*--------------------------------------------------------------
 ## Content
 --------------------------------------------------------------*/


### PR DESCRIPTION
Moved some of the meta links from the primary menu to the footer. They are only needed for developers, but users don't really need to know how to submit a plugin/theme. 

Also Forms menu item is hidden to public but is shown to logged in users. We will need a guide in docs on the process of submitting software to the directory.