### PR TITLE
Fix README.md conversion fallback and improve wp-cli

### DIFF
--- a/wp-content/mu-plugins/download-links.php
+++ b/wp-content/mu-plugins/download-links.php
@@ -233,7 +233,7 @@ function kts_maybe_update( $software_id, $force = false ) {
 		}
 
 		# Get description
-		$readme_index = $zip->locateName( 'README.md', ZipArchive::FL_NOCASE|ZipArchive::FL_NODIR );
+		$readme_index = $zip->locateName( '/README.md', ZipArchive::FL_NOCASE );
 		$readme_md = $zip->getFromIndex( $readme_index, 0, ZipArchive::FL_UNCHANGED );
 		$description = kts_render_md( $readme_md );
 		$description = wp_kses_post( preg_replace('~<h1>.*<\/h1>~', '', $description ) );

--- a/wp-content/mu-plugins/software-submit-form.php
+++ b/wp-content/mu-plugins/software-submit-form.php
@@ -460,7 +460,7 @@ function kts_software_submit_form_redirect() {
 	$slug = strstr( $zip->getNameIndex(0), '/', true );
 
 	# Get description
-	$readme_index = $zip->locateName( 'README.md', ZipArchive::FL_NOCASE|ZipArchive::FL_NODIR );
+	$readme_index = $zip->locateName( '/README.md', ZipArchive::FL_NOCASE );
 	$readme_md = $zip->getFromIndex( $readme_index, 0, ZipArchive::FL_UNCHANGED );
 	$description = kts_render_md( $readme_md );
 	$description = wp_kses_post( preg_replace('~<h1>.*<\/h1>~', '', $description ) );

--- a/wp-content/plugins/dir-cli/dir-cli.php
+++ b/wp-content/plugins/dir-cli/dir-cli.php
@@ -80,6 +80,7 @@ class Dir{
 
 			if ($update === false || $update === true || $update['description'] === '') {
 				\WP_CLI::error('Something went wrong updating "'.$title.'". Check logs for errors.', false);
+				continue;
 			}
 
 			wp_update_post( [

--- a/wp-content/plugins/dir-cli/dir-cli.php
+++ b/wp-content/plugins/dir-cli/dir-cli.php
@@ -40,11 +40,6 @@ class Dir{
 	/**
 	* Force an update of an item.
 	*
-	* ## OPTIONS
-	*
-	* [--id=<ID>]
-	* : ID of the item.
-	*
 	*
 	* ## EXAMPLES
 	*
@@ -76,12 +71,13 @@ class Dir{
 		
 		$valid_types = ['plugin', 'theme', 'snippet'];
 		if (!in_array($type, $valid_types)) {
-			\WP_CLI::error('You can\' update a '.$type.'.');
+			\WP_CLI::error('You can\'t update a '.$type.'.');
 		}
 
 		$update = kts_maybe_update($id, true);
-		if ( $update === false || $update === true ) {
-			\WP_CLI::error('Strange!');;
+
+		if ($update === false || $update === true || $update['description'] === '') {
+			\WP_CLI::error('Something went wrong updating '.$title.'. Check logs for errors.');
 		}
 
 		wp_update_post( [


### PR DESCRIPTION
1. This PR will fix #44.
2. Error checking is enforced.
3. Now `wp dir update` accepts post id(s) as parameter(s), so can be called this way:
wp dir update $(wp post list --post_type='plugin' --format=ids)
