### PR TITLE
Add "published_at" date to API data

### DIFF
--- a/wp-content/mu-plugins/download-links.php
+++ b/wp-content/mu-plugins/download-links.php
@@ -126,7 +126,7 @@ function kts_cron_update_download_links() {
 			'meta_input'	=> array(
 				'download_link'		=> $update['download_link'],
 				'current_version'	=> $update['current_version'],
-				'published_at'      => $update['published_at'],
+				'published_at'		=> $update['published_at'],
 				'requires_php'		=> $update['requires_php'],
 				'requires_cp'		=> $update['requires_cp'],
 			),
@@ -380,7 +380,7 @@ function kts_maybe_update( $software_id, $force = false ) {
 			'description'		=> $description,
 			'requires_php'		=> $headers['RequiresPHP'],
 			'requires_cp'		=> $headers['RequiresCP'],
-			'published_at'      => \DateTime::createFromFormat( 'Y-m-d\TH:i:s\Z', $result->published_at )->format( "Y-m-d" ),
+			'published_at'		=> \DateTime::createFromFormat( 'Y-m-d\TH:i:s\Z', $result->published_at )->format( "Y-m-d" ),
 		);
 	}
 

--- a/wp-content/mu-plugins/download-links.php
+++ b/wp-content/mu-plugins/download-links.php
@@ -85,6 +85,7 @@ function kts_software_update_link_redirect() {
 			'meta_input'	=> array(
 				'download_link'		=> $update['download_link'],
 				'current_version'	=> $update['current_version'],
+				'published_at'      => $update['published_at'],
 				'requires_php'		=> $update['requires_php'],
 				'requires_cp'		=> $update['requires_cp'],
 			),
@@ -125,6 +126,7 @@ function kts_cron_update_download_links() {
 			'meta_input'	=> array(
 				'download_link'		=> $update['download_link'],
 				'current_version'	=> $update['current_version'],
+				'published_at'      => $update['published_at'],
 				'requires_php'		=> $update['requires_php'],
 				'requires_cp'		=> $update['requires_cp'],
 			),
@@ -378,6 +380,7 @@ function kts_maybe_update( $software_id, $force = false ) {
 			'description'		=> $description,
 			'requires_php'		=> $headers['RequiresPHP'],
 			'requires_cp'		=> $headers['RequiresCP'],
+			'published_at'      => \DateTime::createFromFormat( 'Y-m-d\TH:i:s\Z', $result->published_at )->format( "Y-m-d" ),
 		);
 	}
 

--- a/wp-content/mu-plugins/rest-api.php
+++ b/wp-content/mu-plugins/rest-api.php
@@ -98,7 +98,16 @@ function kts_register_meta_with_rest_api() {
 		'object_subtype'=> 'plugin',
 		'show_in_rest'	=> true,
 	);
-	register_meta( 'post', 'active_installations', $plugin_args9 );
+	register_meta( 'post', 'active_installations', $plugin_args10 );
+	
+	$plugin_args11 = array(
+		'type'			=> 'string',
+		'description'	=> 'Release date',
+		'single'		=> true,
+		'object_subtype'=> 'plugin',
+		'show_in_rest'	=> true,
+	);
+	register_meta( 'post', 'published_at', $plugin_args11 );
 
 	$theme_args1 = array(
 		'type'			=> 'string',
@@ -172,14 +181,23 @@ function kts_register_meta_with_rest_api() {
 	);
 	register_meta( 'post', 'tags', $theme_args8 );
 
-	$theme_args8 = array(
+	$theme_args9 = array(
 		'type'			=> 'string',
 		'description'	=> 'Active installations',
 		'single'		=> true,
 		'object_subtype'=> 'theme',
 		'show_in_rest'	=> true,
 	);
-	register_meta( 'post', 'active_installations', $theme_args8 );
+	register_meta( 'post', 'active_installations', $theme_args9 );
+
+	$theme_args10 = array(
+		'type'			=> 'string',
+		'description'	=> 'Release date',
+		'single'		=> true,
+		'object_subtype'=> 'theme',
+		'show_in_rest'	=> true,
+	);
+	register_meta( 'post', 'published_at', $theme_args10 );
 
 }
 add_action( 'init', 'kts_register_meta_with_rest_api' );

--- a/wp-content/mu-plugins/software-submit-form.php
+++ b/wp-content/mu-plugins/software-submit-form.php
@@ -673,6 +673,7 @@ function kts_software_submit_form_redirect() {
 	add_post_meta( $post_id, 'download_link', $download_link );
 	add_post_meta( $post_id, 'requires_php', $headers['RequiresPHP'] );
 	add_post_meta( $post_id, 'requires_cp', $headers['RequiresCP'] );
+	add_post_meta( $post_id, 'published_at', date("Y-m-d") );
 
 	# Add names of categories and tags to meta fields for REST API
 	if ( $post_type === 'plugin' ) {

--- a/wp-content/plugins/dir-cli/dir-cli.php
+++ b/wp-content/plugins/dir-cli/dir-cli.php
@@ -91,6 +91,7 @@ class Dir{
 					'current_version'	=> $update['current_version'],
 					'requires_php'		=> $update['requires_php'],
 					'requires_cp'		=> $update['requires_cp'],
+					'published_at'		=> $update['published_at'],
 				],
 			] );
 


### PR DESCRIPTION
Now when an update is found, the `published_at` data from GitHub is stored in `published_at` post meta.
When a new plugin is submitted, the date will be the submission day.
This data is then sent out by REST API.
Formati is `"Y-m-d"`.

We can manually force this value with:
`wp dir update $(wp post list --post_type='plugin' --format=ids)`

Closes #64.