### PR TITLE
Add status to plugin and themes

### DIFF
--- a/wp-content/mu-plugins/rest-api.php
+++ b/wp-content/mu-plugins/rest-api.php
@@ -109,6 +109,15 @@ function kts_register_meta_with_rest_api() {
 	);
 	register_meta( 'post', 'published_at', $plugin_args11 );
 
+	$plugin_args12 = array(
+		'type'			=> 'string',
+		'description'	=> 'Status',
+		'single'		=> true,
+		'object_subtype'=> 'plugin',
+		'show_in_rest'	=> true,
+	);
+	register_meta( 'post', 'item_status', $plugin_args12 );
+
 	$theme_args1 = array(
 		'type'			=> 'string',
 		'description'	=> 'Current Version of Software',
@@ -198,6 +207,15 @@ function kts_register_meta_with_rest_api() {
 		'show_in_rest'	=> true,
 	);
 	register_meta( 'post', 'published_at', $theme_args10 );
+	
+	$theme_args11 = array(
+		'type'			=> 'string',
+		'description'	=> 'Status',
+		'single'		=> true,
+		'object_subtype'=> 'theme',
+		'show_in_rest'	=> true,
+	);
+	register_meta( 'post', 'item_status', $theme_args11 );
 
 }
 add_action( 'init', 'kts_register_meta_with_rest_api' );

--- a/wp-content/mu-plugins/status.php
+++ b/wp-content/mu-plugins/status.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Plugin Name: Custom Status
+ * Plugin URI: https://directory.classicpress.net/
+ * Description: Adds status to plugins and themes
+ * Author: Simone Fioravanti
+ * Version: 0.1.0
+ */
+
+namespace ClassicPress\Status;
+
+if (!defined('ABSPATH')) {
+	die('-1');
+}
+
+
+class Status{
+
+	private $statuses = [];
+
+	public function __construct() {
+
+		$this->statuses = [
+				'active'    => esc_html__('Active', 'classicpress-directory'),
+				'suspended' => esc_html__('Suspended', 'classicpress-directory'),
+				'closed'    => esc_html__('Closed', 'classicpress-directory'),
+				'ownership' => esc_html__('Ownership changed', 'classicpress-directory'),
+				'adoption'  => esc_html__('Adobtable', 'classicpress-directory'),
+			];
+
+		add_action('add_meta_boxes', [$this, 'status_add_meta_box']);
+		add_action('save_post_plugin', [$this, 'status_save'], 10, 1);
+		add_action('save_post_theme', [$this, 'status_save'], 10, 1);
+
+	}
+
+	public function status_add_meta_box() {
+		add_meta_box('cpdir-status', esc_html__('Status', 'classicpress-directory'), [$this, 'status_render_meta_box'], ['plugin', 'theme'], 'side');
+	}
+
+	private function render_select($status) {
+		echo '<div id="directory-status">';
+		echo '<select name="cpdir_status" id="cpdir_status">';
+		foreach ($this->statuses as $key => $value) {
+			$selected = $status === $key ? ' selected' : '';
+			echo '<option value="'.sanitize_key($key).'"'.sanitize_key($selected).'>'.esc_html($value).'</option>';
+		}
+		echo '</select>';
+		wp_nonce_field('change_status', 'change_status__nonce');
+		echo '</div>';
+	}
+
+	public function status_render_meta_box($post) {
+		$status = get_post_meta($post->ID, 'item_status', true);
+		$status = array_key_exists($status, $this->statuses) ? $status : 'active';
+		$this->render_select($status);
+	}
+
+	public function status_save($post_ID) {
+		if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+			return;
+		}
+		if (!current_user_can('edit_post', $post_ID)) {
+			return;
+		}
+		if (check_admin_referer('change_status', 'change_status__nonce') === false) {
+			return;
+		}
+		if (!array_key_exists('cpdir_status', $_REQUEST)) {
+			return;
+		}
+		$status = sanitize_key(wp_unslash($_REQUEST['cpdir_status']));
+		if (!array_key_exists($status, $this->statuses)) {
+		return;
+		}
+		update_post_meta($post_ID, 'item_status', $status);
+	}
+
+}
+
+new Status;
+
+
+
+

--- a/wp-content/mu-plugins/status.php
+++ b/wp-content/mu-plugins/status.php
@@ -26,7 +26,7 @@ class Status{
 				'suspended' => esc_html__('Suspended', 'classicpress-directory'),
 				'closed'    => esc_html__('Closed', 'classicpress-directory'),
 				'ownership' => esc_html__('Ownership changed', 'classicpress-directory'),
-				'adoption'  => esc_html__('Adobtable', 'classicpress-directory'),
+				'adoption'  => esc_html__('Adoptable', 'classicpress-directory'),
 			];
 
 		add_action('add_meta_boxes', [$this, 'status_add_meta_box']);


### PR DESCRIPTION
This PR add a status meta to plugins and themes.
Default status is _Active_.
Other status are _Suspended_, _Closed_, _Ownership changed_ and _Adoptable_. (Please reword them if needed)

The status is exposed in REST API as `meta-> item_status`.

The status has not to be confused with post status, that is _publish_ or _draft_ for plugin or themes thar have been submitted but have not yet passed the review.

<img width="308" alt="Schermata 2023-01-19 alle 11 57 04" src="https://user-images.githubusercontent.com/29772709/213443225-d08af911-4ee0-4983-8c20-e3ad65f13b4e.png">

Closes #63.