### PR TITLE
Fix broken regex

### DIFF
--- a/wp-content/plugins/fix-dir-images/fix-dir-images.php
+++ b/wp-content/plugins/fix-dir-images/fix-dir-images.php
@@ -43,7 +43,7 @@ class FixDirImages {
 		}
 
 		$prefix = preg_replace(
-			'~https://github.com/([a-zA-Z1-9\-_]+)/([a-zA-Z1-9\-_]+)/releases/download/([a-zA-Z1-9\-_\.]+)/.*$~',
+			'~https://github.com/([a-zA-Z0-9\-_]+)/([a-zA-Z0-9\-_]+)/releases/download/([a-zA-Z0-9\-_\.]+)/.*$~',
 			'https://raw.githubusercontent.com/$1/$2/$3/',
 			$github_repo
 		);


### PR DESCRIPTION
Fix a [broken regex](https://github.com/ClassicPress/Directory/blob/0660a69c9041599bcab0b0ca9244782e43f42d1b/wp-content/plugins/fix-dir-images/fix-dir-images.php#L46) in Fix Dir Image plugin.